### PR TITLE
[DEVX-1336] Use testcafe-reporter-sauce-json package to generate the sauce test report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "^0.0.2",
-        "saucelabs": "^6.1.0"
+        "saucelabs": "^6.1.0",
+        "testcafe-reporter-sauce-json": "^0.0.1"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -9865,6 +9866,19 @@
       "integrity": "sha1-Z28DVHY0FDxurzq1KGgnOkvr9CE=",
       "dev": true
     },
+    "node_modules/testcafe-reporter-sauce-json": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.0.1.tgz",
+      "integrity": "sha512-67iqsN6+IXKxGfbNJ4erpUHFVYXKK4lQdUeWPUWF21SVC5XIuub6JaYZVwj5vKbtYoHP0+ir0argMbNaK8EgQQ==",
+      "dependencies": {
+        "@saucelabs/sauce-json-reporter": "^0.0.3"
+      }
+    },
+    "node_modules/testcafe-reporter-sauce-json/node_modules/@saucelabs/sauce-json-reporter": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-0.0.3.tgz",
+      "integrity": "sha512-ccSna51MSTrbP3OlC5ZbweOsFrMTTAYUQcJM6qOvv+PUkkep02WaC8Je2J8C8PGPjRGeDhChwEiT8pTALPxqfQ=="
+    },
     "node_modules/testcafe-reporter-spec": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/testcafe-reporter-spec/-/testcafe-reporter-spec-2.1.1.tgz",
@@ -18762,6 +18776,21 @@
       "resolved": "https://registry.npmjs.org/testcafe-reporter-minimal/-/testcafe-reporter-minimal-2.1.0.tgz",
       "integrity": "sha1-Z28DVHY0FDxurzq1KGgnOkvr9CE=",
       "dev": true
+    },
+    "testcafe-reporter-sauce-json": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.0.1.tgz",
+      "integrity": "sha512-67iqsN6+IXKxGfbNJ4erpUHFVYXKK4lQdUeWPUWF21SVC5XIuub6JaYZVwj5vKbtYoHP0+ir0argMbNaK8EgQQ==",
+      "requires": {
+        "@saucelabs/sauce-json-reporter": "^0.0.3"
+      },
+      "dependencies": {
+        "@saucelabs/sauce-json-reporter": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-0.0.3.tgz",
+          "integrity": "sha512-ccSna51MSTrbP3OlC5ZbweOsFrMTTAYUQcJM6qOvv+PUkkep02WaC8Je2J8C8PGPjRGeDhChwEiT8pTALPxqfQ=="
+        }
+      }
     },
     "testcafe-reporter-spec": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "^0.0.2",
         "saucelabs": "^6.1.0",
-        "testcafe-reporter-sauce-json": "^0.0.1"
+        "testcafe-reporter-sauce-json": "^0.0.2"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -9867,9 +9867,9 @@
       "dev": true
     },
     "node_modules/testcafe-reporter-sauce-json": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.0.1.tgz",
-      "integrity": "sha512-67iqsN6+IXKxGfbNJ4erpUHFVYXKK4lQdUeWPUWF21SVC5XIuub6JaYZVwj5vKbtYoHP0+ir0argMbNaK8EgQQ==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.0.2.tgz",
+      "integrity": "sha512-/0eHV7cqkC6iyY5Hr7pTBa8AZmVfbsVogkwLd3OHJrqtE8O1ukIQeX3SPTaupaIxDeca7lwunRA48cxI+BGnMg==",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "^0.0.3"
       }
@@ -18778,9 +18778,9 @@
       "dev": true
     },
     "testcafe-reporter-sauce-json": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.0.1.tgz",
-      "integrity": "sha512-67iqsN6+IXKxGfbNJ4erpUHFVYXKK4lQdUeWPUWF21SVC5XIuub6JaYZVwj5vKbtYoHP0+ir0argMbNaK8EgQQ==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.0.2.tgz",
+      "integrity": "sha512-/0eHV7cqkC6iyY5Hr7pTBa8AZmVfbsVogkwLd3OHJrqtE8O1ukIQeX3SPTaupaIxDeca7lwunRA48cxI+BGnMg==",
       "requires": {
         "@saucelabs/sauce-json-reporter": "^0.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   "dependencies": {
     "@saucelabs/sauce-json-reporter": "^0.0.2",
     "saucelabs": "^6.1.0",
-    "testcafe-reporter-sauce-json": "^0.0.1"
+    "testcafe-reporter-sauce-json": "^0.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@saucelabs/sauce-json-reporter": "^0.0.2",
-    "saucelabs": "^6.1.0"
+    "saucelabs": "^6.1.0",
+    "testcafe-reporter-sauce-json": "^0.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ module.exports = function () {
                 .newline();
         },
 
-        specEndConsole (jobURL) {
+        specEndConsole (jobURL, userAgent) {
             if (!jobURL) {
                 return;
             }
@@ -67,7 +67,7 @@ module.exports = function () {
             this.setIndent(2)
                 .useWordWrap(true)
                 .newline()
-                .write(`Sauce Labs Report: ${jobURL}`)
+                .write(`Sauce Labs Report (${userAgent}): ${jobURL}`)
                 .newline();
         },
 
@@ -160,7 +160,7 @@ module.exports = function () {
                         testRun: s.testRun,
                     });
 
-                    this.specEndConsole(jobUrl);
+                    this.specEndConsole(jobUrl, s.userAgent);
                 } catch (e) {
                     this.error(`Sauce Labs Report Failed: ${e.message}`);
                 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const { SauceJsonReporter } = require('testcafe-reporter-sauce-json/reporter');
 const { Reporter, Test } = require('./reporter');
 const path = require('path');
 
@@ -11,12 +12,16 @@ module.exports = function () {
         startTime:      null,
         startTimes:     new Map(),
 
+        sauceTestReport: SauceJsonReporter.newReporter(),
+
         reportTaskStart (startTime, userAgents, testCount, testStructure, properties) {
             this.reporter = new Reporter(this, properties.configuration.sauce);
             this.startTime = startTime;
             this.testCount = testCount;
 
             this.taskStartConsole(userAgents);
+
+            this.sauceTestReport.reportTaskStart(startTime, userAgents, testCount);
         },
 
         taskStartConsole (userAgents) {
@@ -35,6 +40,7 @@ module.exports = function () {
         },
 
         async reportFixtureStart (name, specPath) {
+            this.sauceTestReport.reportFixtureStart(name, specPath);
             // Flush pending reports when we encounter a new spec.
             if (this.specPath !== specPath) {
                 this.specEndConsole(await this.reporter.flush());
@@ -84,10 +90,13 @@ module.exports = function () {
         },
 
         reportTestStart (name, meta, testStartInfo) {
+            this.sauceTestReport.reportTestStart(name, meta, testStartInfo);
             this.startTimes.set(testStartInfo.testId, new Date());
         },
 
         async reportTestDone (name, testRunInfo) {
+            this.sauceTestReport.reportTestDone(name, testRunInfo);
+
             const startTime = this.startTimes.get(testRunInfo.testId);
             this.startTimes.delete(testRunInfo.testId);
 
@@ -166,6 +175,9 @@ module.exports = function () {
         },
 
         async reportTaskDone (endTime, passed, warnings) {
+            this.sauceTestReport.reportTaskDone(endTime, passed, warnings);
+
+            console.log(this.sauceTestReport.assets);
             this.specEndConsole(await this.reporter.flush());
             this.taskDoneConsole(endTime, passed, warnings);
         },

--- a/src/index.js
+++ b/src/index.js
@@ -145,12 +145,10 @@ module.exports = function () {
         async reportTaskDone (endTime, passed, warnings) {
             this.sauceTestReport.reportTaskDone(endTime, passed, warnings);
 
-            this.taskDoneConsole(endTime, passed, warnings);
-
             const sessions = this.sauceTestReport.sessions;
             for (const s of [...sessions.values()]) {
                 try {
-                    const url = await this.reporter.reportSession({
+                    const jobUrl = await this.reporter.reportSession({
                         name: s.userAgent,
                         startTime: s.startTime,
                         endTime: s.endTime,
@@ -162,11 +160,12 @@ module.exports = function () {
                         testRun: s.testRun,
                     });
 
-                    this.specEndConsole(url);
+                    this.specEndConsole(jobUrl);
                 } catch (e) {
                     this.error(`Sauce Labs Report Failed: ${e.message}`);
                 }
             }
+            this.taskDoneConsole(endTime, passed, warnings);
         },
 
         taskDoneConsole (endTime, passed, warnings) {

--- a/src/index.js
+++ b/src/index.js
@@ -151,20 +151,13 @@ module.exports = function () {
             for (const s of [...sessions.values()]) {
                 try {
                     const url = await this.reporter.reportSession({
-                        // TODO Need a reasonable name for the sauce job
-                        specPath: s.userAgent,
+                        name: s.userAgent,
                         startTime: s.startTime,
                         endTime: s.endTime,
-                        status: s.testRun.computeStatus(),
-                        browser: {
-                            prettyUserAgent: s.userAgent,
-                            name: s._browser.name,
-                            version: s._browser.version,
-                            os: {
-                                name: s._platform.name,
-                                version: s._platform.version,
-                            },
-                        },
+                        userAgent: s.userAgent,
+                        browserName: s.browserName,
+                        browserVersion: s.browserVersion,
+                        platformName: s.platform,
                         assets: s.assets,
                         testRun: s.testRun,
                     });

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,51 +1,8 @@
 const SauceLabs = require('saucelabs').default;
-const {Status, TestRun, Suite, Attachment} = require('@saucelabs/sauce-json-reporter');
+const { Status } = require('@saucelabs/sauce-json-reporter');
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
-
-class Session {
-
-    constructor (browser, specPath, tests = []) {
-        this.browser = browser;
-        this.specPath = specPath;
-        this.tests = tests;
-
-        this.passed = true;
-        this.startTime = null;
-        this.endTime = null;
-    }
-
-    addTest (test) {
-        this.passed = this.passed && !test.errs.length;
-
-        if (!this.startTime || test.startTime < this.startTime) {
-            this.startTime = test.startTime;
-        }
-
-        if (!this.endTime || test.endTime > this.endTime) {
-            this.endTime = test.endTime;
-        }
-
-        this.tests.push(test);
-    }
-}
-
-class Test {
-    constructor (name, fixtureName, browser, specPath = '', startTime = new Date(),
-        endTime = new Date(), errs = [], warnings = [], screenshots = [], video) {
-        this.name = name;
-        this.fixtureName = fixtureName;
-        this.browser = browser;
-        this.specPath = specPath;
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.errs = errs;
-        this.warnings = warnings;
-        this.screenshots = screenshots;
-        this.video = video;
-    }
-}
 
 class Reporter {
     constructor (logger = console, opts = {}) {
@@ -76,28 +33,6 @@ class Reporter {
         this.session = null;
     }
 
-    addTest (test) {
-        if (!this.session) {
-            this.session = new Session(test.browser, test.specPath);
-        }
-
-        this.session.addTest(test);
-    }
-
-    async flush () {
-        if (!this.session) {
-            return;
-        }
-
-        try {
-            return await this.reportSession(this.session);
-        } catch (e) {
-            this.log.error(`Sauce Labs Report Failed: ${e.message}`);
-        } finally {
-            this.session = null;
-        }
-    }
-
     isAccountSet () {
         return this.username && this.accessKey;
     }
@@ -116,7 +51,7 @@ class Reporter {
             frameworkVersion: '0.0.0', // TODO https://github.com/DevExpress/testcafe/issues/6591
             status:           'complete',
             suite:            session.specPath,
-            passed:           session.passed,
+            passed:           session.status === Status.Passed,
             build:            this.build,
             tags:             this.tags,
             browserName:      session.browser.name,
@@ -126,65 +61,18 @@ class Reporter {
 
         const sessionId = await this.createJob(body);
 
-        let assets = [
-            this.createConsoleLog(session),
-            this.createSauceTestReport(session),
-            ...this.getVideos(session.tests),
-            ...this.getScreenshots(session.tests)];
+        const assets = session.assets.map((a) => {
+            return {filename: a.name, data: a.localPath };
+        });
+        assets.push({
+            filename: 'sauce-test-report.json',
+            data: session.testRun,
+        });
+        assets.push(this.createConsoleLog(session));
 
         await this.uploadAssets(sessionId, assets);
 
         return this.getJobURL(sessionId);
-    }
-
-    createSauceTestReport(session) {
-        const testRun = new TestRun();
-        testRun.status = session.passed ? Status.Passed : Status.Failed;
-
-        let suite, fixture;
-
-        for (const test of session.tests) {
-            suite = testRun.withSuite(test.specPath);
-            fixture = suite.withSuite(test.fixtureName);
-
-            let duration;
-            if (test.startTime && test.endTime) {
-                duration = test.endTime - test.startTime;
-            }
-
-            const testStatus = (test.errs && test.errs.length) ? Status.Failed : Status.Passed;
-            suite.status = suite.status === Status.Passed ? testStatus : suite.status;
-            fixture.status = fixture.status === Status.Passed ? testStatus : fixture.status;
-
-            const addedTest = fixture.withTest(
-                test.name,
-                testStatus,
-                duration,
-                '',
-                test.startTime,
-                { browser: test.browser.name },
-            );
-
-            if (test.video) {
-                addedTest.attach({
-                    name: `${test.name}`,
-                    contentType: 'video/mp4',
-                    path: `${test.name}.mp4`,
-                });
-            }
-            for (const screenshot of test.screenshots) {
-                const filename = this.getScreenshotName(test.name, screenshot.screenshotPath);
-                addedTest.attach({
-                    name: filename,
-                    contentType: 'image/png',
-                    path: filename,
-                });
-            }
-        }
-        return {
-            filename: 'sauce-test-report.json',
-            data: testRun,
-        };
     }
 
     async createJob (body) {
@@ -206,48 +94,43 @@ class Reporter {
         );
     }
 
+    logSuite (suite, depth = 0) {
+        const indent = ' '.repeat(depth * 4);
+        const result = suite.status === Status.Passed ? '✓' : '✖';
+        let log = `${indent}${result} ${suite.name}\n`;
+        for (const t of suite.tests) {
+            log += this.logTest(t, depth + 1);
+        }
+
+        for (const s of suite.suites) {
+            log += this.logSuite(s, depth + 1);
+        }
+
+        return log;
+    }
+
+    logTest(test, depth = 0) {
+        const indent = ' '.repeat(depth * 4);
+        const result = test.status === Status.Passed ? '✓' : '✖';
+        const name = test.name;
+        const duration = test.duration;
+
+        let error = '';
+        if (test.status !== Status.Passed && test.output !== '') {
+            error = `\n\n${indent}\n${test.output}\n\n`;
+        }
+
+        return `${indent}${result} ${name} (${duration}ms)${error}\n`;
+    }
+
     createConsoleLog (session) {
+        const testRun = session.testRun;
         let log = `Running tests in: ${session.browser.prettyUserAgent}\n\n\n`;
 
-        log += 'Results:\n';
-        for (let test of session.tests) {
-            const errors = test.errs;
-            const warnings = test.warnings;
-            const hasErrors = !!errors.length;
-            const hasWarnings = !!warnings.length;
-            const result = hasErrors ? '✖' : '✓';
-
-            log += `  ${result} ${test.fixtureName} - ${test.name}\n`;
-
-            if (hasErrors) {
-                log += '\n    Errors:\n';
-
-                errors.forEach(error => {
-                    if (error) {
-                        const errLines = error.split('\n');
-                        for (let err of errLines) {
-                            log += `        ${err}\n`;
-                        }
-                    }
-                });
-            }
-
-            if (hasWarnings) {
-                log += '\n    Warnings:\n';
-
-                warnings.forEach(warning => {
-                    if (warning) {
-                        const warLines = warning.split('\n');
-                        for (let war of warLines) {
-                            log += `        ${war}\n`;
-                        }
-                    }
-                });
-            }
-
-            if (hasErrors || hasWarnings) {
-                log += '\n';
-            }
+        log += 'Results:\n\n';
+        for (const s of testRun.suites) {
+            log += this.logSuite(s, 1);
+            log += '\n';
         }
 
         return {
@@ -265,48 +148,10 @@ class Reporter {
 
         return `https://${domainMapping[this.region]}/tests/${sessionId}`;
     }
-
-    getVideos (tests) {
-        return tests
-            .filter(test => test.video)
-            .map(test => {
-                return {
-                    filename: `${test.name}.mp4`,
-                    data:     this.maybeReadFile(test.video.videoPath)
-                };
-            })
-            .filter(artifact => artifact.data);
-    }
-
-    getScreenshots (tests) {
-        return tests.flatMap(test => {
-            return test.screenshots.map(screenshot => {
-                return {
-                    filename: this.getScreenshotName(test.name, screenshot.screenshotPath),
-                    data:     this.maybeReadFile(screenshot.screenshotPath)
-                };
-            })
-                .filter(artifact => artifact.data);
-        });
-    }
-
-    getScreenshotName (testName, filePath) {
-        // There can be multiple screenshots per test. Using a suffix to avoid collisions.
-        const suffix = path.basename(filePath);
-        return `${testName} - ${suffix}`;
-    }
-
-    maybeReadFile (filepath) {
-        try {
-            return fs.readFileSync(filepath);
-        } catch (e) {
-            this.log.log(`Failed to read contents of ${filepath}:`, e.message);
-        }
-    }
 }
 
 function randomBuildID () {
     return crypto.randomBytes(6).readUIntLE(0, 6).toString(36);
 }
 
-module.exports = { Reporter, Test };
+module.exports = { Reporter };

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -97,9 +97,9 @@ class Reporter {
     }
 
     logSuite (suite, depth = 0) {
-        const indent = ' '.repeat(depth * 4);
-        const result = suite.status === Status.Passed ? '✓' : '✖';
-        let log = `${indent}${result} ${suite.name}\n`;
+        const indent = '    '.repeat(depth);
+        const resultIcon = suite.status === Status.Passed ? '✓' : '✖';
+        let log = `${indent}${resultIcon} ${suite.name}\n`;
         for (const t of suite.tests) {
             log += this.logTest(t, depth + 1);
         }
@@ -111,9 +111,9 @@ class Reporter {
         return log;
     }
 
-    logTest(test, depth = 0) {
-        const indent = ' '.repeat(depth * 4);
-        const result = test.status === Status.Passed ? '✓' : '✖';
+    logTest (test, depth = 0) {
+        const indent = '    '.repeat(depth);
+        const resultIcon = test.status === Status.Passed ? '✓' : '✖';
         const name = test.name;
         const duration = test.duration;
 
@@ -122,7 +122,7 @@ class Reporter {
             error = `\n\n${indent}\n${test.output}\n\n`;
         }
 
-        return `${indent}${result} ${name} (${duration}ms)${error}\n`;
+        return `${indent}${resultIcon} ${name} (${duration}ms)${error}\n`;
     }
 
     createConsoleLog (testRun, userAgent) {


### PR DESCRIPTION
Delegate the creation of the sauce test report to `testcafe-reporter-sauce-json` package. When the tests are finished, use its results to create reports on sauce.

example jobs:
https://app.saucelabs.com/tests/6bda8ddd03fe477387c2c00a0cff6ffc
https://app.saucelabs.com/tests/34086f0f780a4b739453eb3b81b6274d
https://app.saucelabs.com/tests/639bcb5d464b496eb0739df98bada056

**N.B.**
The report creation component of `testcafe-reporter-sauce-json` organizes the test results by browser instead of by spec file. So for a given testcafe run, each browser under test will correspond to a job on sauce and each job has test results for one or more spec files. tbh, having now seen a bunch of test results organized this way, I actually think its better to have a job per spec. e.g. if there are two spec files run against two browsers, we should create 4 jobs.

So if there's a team preference to organize jobs in this way, I'm happy to re-work this PR to accommodate. I figured I'd open the PR anyways to start the discussion.