### PR TITLE
Support non-env var configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,20 @@ npm install testcafe-reporter-saucelabs
 to Sauce Labs. Your Sauce Labs Username and Access Key are available from your
 [dashboard](https://app.saucelabs.com/user-settings).
 
+Alternatively, you can use `username` and `accessKey` fields in the reporter configuration.
+
 ### TestCafe Configuration
 
 To configure the reporter, simply extend your TestCafe configuration file (e.g. `.testcaferc.js`):
 
 ```js
 module.exports = {
-    "sauce": {
-        "build":  "build123",
-        "tags":   [
+    sauce: {
+        build:  "build123",
+        tags:   [
             "app101",
         ],
-        "region": "us-west-1",
+        region: "us-west-1",
     }
 }
 ```

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -58,14 +58,16 @@ class Reporter {
         } catch (e) {
         }
 
+        this.username = opts.username || process.env.SAUCE_USERNAME;
+        this.accessKey = opts.accessKey || process.env.SAUCE_ACCESS_KEY;
         this.build = opts.build || randomBuildID();
         this.tags = opts.tags;
         this.region = opts.region || 'us-west-1';
         const tld = this.region === 'staging' ? 'net' : 'com';
 
         this.api = new SauceLabs({
-            user:    process.env.SAUCE_USERNAME,
-            key:     process.env.SAUCE_ACCESS_KEY,
+            user:    this.username,
+            key:     this.accessKey,
             region:  this.region,
             tld:     tld,
             headers: { 'User-Agent': `testcafe-reporter/${reporterVersion}` }
@@ -97,7 +99,7 @@ class Reporter {
     }
 
     isAccountSet () {
-        return process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY;
+        return this.username && this.accessKey;
     }
 
     async reportSession (session) {


### PR DESCRIPTION
Allow `username`/`accessKey` to be set from configuration instead of env vars.