### PR TITLE
[DEVX-1432] Fix error on split

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "testcafe-reporter-saucelabs",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "^0.0.2",

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -223,9 +223,11 @@ class Reporter {
                 log += '\n    Errors:\n';
 
                 errors.forEach(error => {
-                    const errLines = error.split('\n');
-                    for (let err of errLines) {
-                        log += `        ${err}\n`;
+                    if (error) {
+                        const errLines = error.split('\n');
+                        for (let err of errLines) {
+                            log += `        ${err}\n`;
+                        }
                     }
                 });
             }
@@ -234,9 +236,11 @@ class Reporter {
                 log += '\n    Warnings:\n';
 
                 warnings.forEach(warning => {
-                    const warLines = warning.split('\n');
-                    for (let war of warLines) {
-                        log += `        ${war}\n`;
+                    if (warning) {
+                        const warLines = warning.split('\n');
+                        for (let war of warLines) {
+                            log += `        ${war}\n`;
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Check that `error` / `warning` contains something before splitting its content.