### PR TITLE
[DEVX-1439] dynamic job name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ module.exports = function () {
             const sessions = this.sauceTestReport.sessions;
             for (const s of [...sessions.values()]) {
                 let jobName = s.userAgent;
-                if (this.config.name !== '') {
+                if (this.config && this.config.name !== '') {
                     jobName = `${this.config.name} - ${s.userAgent}`;
                 }
                 try {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -20,6 +20,7 @@ class Reporter {
         this.build = opts.build || randomBuildID();
         this.tags = opts.tags;
         this.region = opts.region || 'us-west-1';
+        this.jobName = opts.name || '';
         const tld = this.region === 'staging' ? 'net' : 'com';
 
         this.api = new SauceLabs({


### PR DESCRIPTION
### What 
* Allow job name to be configured in testcafe config

**e.g.**
```js
{
module.exports = {
    sauce: {
        build:  "build123",
        name: process.env.CI_JOB_NAME,
        tags:   [
            "app101",
        ],
        region: "us-west-1",
    }
}
```

### Why
* If running in CI, it allows users to set the job name containing the uploaded sauce report to match the job name in their pipeline.

e.g.
instead of this:
![Screen Shot 2022-01-14 at 9 51 29 AM](https://user-images.githubusercontent.com/56001373/149553812-27cdee17-1059-40a5-93af-1b8ae8dae683.png)

we can have this:
![Screen Shot 2022-01-14 at 9 53 09 AM](https://user-images.githubusercontent.com/56001373/149553883-8034e865-7950-4ce0-a76b-9b9d8beaac24.png)
