### PR TITLE
[DEVX-1447] per spec upload

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "^0.0.2",
         "saucelabs": "^6.1.0",
-        "testcafe-reporter-sauce-json": "0.1.0"
+        "testcafe-reporter-sauce-json": "0.1.1"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -9867,9 +9867,9 @@
       "dev": true
     },
     "node_modules/testcafe-reporter-sauce-json": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.1.0.tgz",
-      "integrity": "sha512-0ASlfPmO3poCRnnAKWDRkHCI562njnYkx39hUEbVHqNywp1mk/1Y/H+QFpQhSW+c1GzKMUWXTwNMThHOkQ3YHw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.1.1.tgz",
+      "integrity": "sha512-k7iIjwfL5r7VY5Cu6JOSbCRaSCoc7RGTvinAeSOuzwX4QyhvWelEgA1OFtSOTZ8ZOU0AOVu48+y0eVoh7BMgyQ==",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "^0.0.3"
       }
@@ -18778,9 +18778,9 @@
       "dev": true
     },
     "testcafe-reporter-sauce-json": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.1.0.tgz",
-      "integrity": "sha512-0ASlfPmO3poCRnnAKWDRkHCI562njnYkx39hUEbVHqNywp1mk/1Y/H+QFpQhSW+c1GzKMUWXTwNMThHOkQ3YHw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.1.1.tgz",
+      "integrity": "sha512-k7iIjwfL5r7VY5Cu6JOSbCRaSCoc7RGTvinAeSOuzwX4QyhvWelEgA1OFtSOTZ8ZOU0AOVu48+y0eVoh7BMgyQ==",
       "requires": {
         "@saucelabs/sauce-json-reporter": "^0.0.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "testcafe-reporter-saucelabs",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "^0.0.2",
         "saucelabs": "^6.1.0",
-        "testcafe-reporter-sauce-json": "^0.0.2"
+        "testcafe-reporter-sauce-json": "0.1.0"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -9867,9 +9867,9 @@
       "dev": true
     },
     "node_modules/testcafe-reporter-sauce-json": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.0.2.tgz",
-      "integrity": "sha512-/0eHV7cqkC6iyY5Hr7pTBa8AZmVfbsVogkwLd3OHJrqtE8O1ukIQeX3SPTaupaIxDeca7lwunRA48cxI+BGnMg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.1.0.tgz",
+      "integrity": "sha512-0ASlfPmO3poCRnnAKWDRkHCI562njnYkx39hUEbVHqNywp1mk/1Y/H+QFpQhSW+c1GzKMUWXTwNMThHOkQ3YHw==",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "^0.0.3"
       }
@@ -18778,9 +18778,9 @@
       "dev": true
     },
     "testcafe-reporter-sauce-json": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.0.2.tgz",
-      "integrity": "sha512-/0eHV7cqkC6iyY5Hr7pTBa8AZmVfbsVogkwLd3OHJrqtE8O1ukIQeX3SPTaupaIxDeca7lwunRA48cxI+BGnMg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.1.0.tgz",
+      "integrity": "sha512-0ASlfPmO3poCRnnAKWDRkHCI562njnYkx39hUEbVHqNywp1mk/1Y/H+QFpQhSW+c1GzKMUWXTwNMThHOkQ3YHw==",
       "requires": {
         "@saucelabs/sauce-json-reporter": "^0.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   "dependencies": {
     "@saucelabs/sauce-json-reporter": "^0.0.2",
     "saucelabs": "^6.1.0",
-    "testcafe-reporter-sauce-json": "^0.0.2"
+    "testcafe-reporter-sauce-json": "0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   "dependencies": {
     "@saucelabs/sauce-json-reporter": "^0.0.2",
     "saucelabs": "^6.1.0",
-    "testcafe-reporter-sauce-json": "0.1.0"
+    "testcafe-reporter-sauce-json": "0.1.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -52,8 +52,8 @@ module.exports = function () {
                     (async () => {
                         const session = {
                             name: f.path,
-                            startTime: new Date(Date.now() - 5 * 1000),
-                            endTime: new Date(),
+                            startTime: f.startTime,
+                            endTime: f.endTime,
                             testRun: browserTestRun.testRun,
                             browserName: browserTestRun.browserName,
                             browserVersion: browserTestRun.browserVersion,

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 module.exports = function () {
     return {
-        indentWidth: 2,
+        indentWidth:    2,
         specPath:       '',
         relSpecPath:    '',
         fixtureName:    '',

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ const path = require('path');
 
 module.exports = function () {
     return {
-        noColors:       true,
         specPath:       '',
         relSpecPath:    '',
         fixtureName:    '',

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 const { SauceJsonReporter } = require('testcafe-reporter-sauce-json/reporter');
 const { Reporter } = require('./reporter');
 const path = require('path');
@@ -73,7 +74,7 @@ module.exports = function () {
                 });
                 reportTasks.push(task);
             }
-            await Promise.all(reportTasks);
+            await Promise.allSettled(reportTasks);
             this.newline();
         },
 

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,7 @@ module.exports = function () {
         },
 
         _renderErrors (errs) {
-            this.setIndent(3)
+            this.setIndent(this.indentWidth * 4)
                 .newline();
 
             errs.forEach((err, idx) => {
@@ -222,15 +222,15 @@ module.exports = function () {
 
         _renderWarnings (warnings) {
             this.newline()
-                .setIndent(1)
+                .setIndent(this.indentWidth * 4)
                 .write(this.chalk.bold.yellow(`Warnings (${warnings.length}):`))
                 .newline();
 
             warnings.forEach(msg => {
-                this.setIndent(1)
+                this.setIndent(this.indentWidth * 4)
                     .write(this.chalk.bold.yellow('--'))
                     .newline()
-                    .setIndent(2)
+                    .setIndent(this.indentWidth * 5)
                     .write(msg)
                     .newline();
             });

--- a/src/index.js
+++ b/src/index.js
@@ -39,15 +39,16 @@ module.exports = function () {
         },
 
         async reportFixtureStart (name, specPath) {
-            this.sauceTestReport.reportFixtureStart(name, specPath);
-            if (this.specPath !== specPath) {
-                this.specPath = specPath;
-                this.relSpecPath = path.relative(process.cwd(), this.specPath);
-                this.specStartConsole(this.relSpecPath);
+            if (this.specPath && this.specPath !== specPath) {
+                // End of currently running spec
             }
 
-            this.fixtureName = name;
+            this.sauceTestReport.reportFixtureStart(name, specPath);
+            this.specPath = specPath;
+            this.relSpecPath = path.relative(process.cwd(), this.specPath);
+            this.specStartConsole(this.relSpecPath);
 
+            this.fixtureName = name;
             this.fixtureStartConsole(name);
         },
 
@@ -58,17 +59,17 @@ module.exports = function () {
                 .newline();
         },
 
-        specEndConsole (jobURL, userAgent) {
-            if (!jobURL) {
-                return;
-            }
+        // specEndConsole (jobURL) {
+        //     if (!jobURL) {
+        //         return;
+        //     }
 
-            this.setIndent(2)
-                .useWordWrap(true)
-                .newline()
-                .write(`Sauce Labs Report (${userAgent}): ${jobURL}`)
-                .newline();
-        },
+        //     this.setIndent(2)
+        //         .useWordWrap(true)
+        //         .newline()
+        //         .write(`Sauce Labs Report (${userAgent}): ${jobURL}`)
+        //         .newline();
+        // },
 
         fixtureStartConsole (name) {
             this.setIndent(2)
@@ -144,27 +145,83 @@ module.exports = function () {
         async reportTaskDone (endTime, passed, warnings) {
             this.sauceTestReport.reportTaskDone(endTime, passed, warnings);
 
-            const sessions = this.sauceTestReport.sessions;
-            for (const s of [...sessions.values()]) {
-                try {
-                    const jobUrl = await this.reporter.reportSession({
-                        name: s.userAgent,
-                        startTime: s.startTime,
-                        endTime: s.endTime,
-                        userAgent: s.userAgent,
-                        browserName: s.browserName,
-                        browserVersion: s.browserVersion,
-                        platformName: s.platform,
-                        assets: s.assets,
-                        testRun: s.testRun,
-                    });
-
-                    this.specEndConsole(jobUrl, s.userAgent);
-                } catch (e) {
-                    this.error(`Sauce Labs Report Failed: ${e.message}`);
-                }
-            }
             this.taskDoneConsole(endTime, passed, warnings);
+
+            if (this.sauceTestReport.fixtures.length > 0) {
+                this.setIndent(2)
+                    .useWordWrap(true)
+                    .newline()
+                    .write(this.chalk.underline.bold('Sauce Labs Report'))
+                    .newline();
+            }
+
+            const reports = this.sauceTestReport.fixtures.flatMap((f) => {
+                const mappedRuns = [];
+                for (const [userAgent, browserTestRun] of f.browserTestRuns) {
+                    return new Promise((resolve) => {
+                        (async () => {
+                            const session = {
+                                name: f.path,
+                                startTime: f.startTime,
+                                endTime: f.endTime,
+                                testRun: browserTestRun.testRun,
+                                browserName: browserTestRun.browserName,
+                                browserVersion: browserTestRun.browserVersion,
+                                platformName: browserTestRun.platform,
+                                assets: browserTestRun.assets,
+                                userAgent: userAgent,
+                            };
+                            try {
+                                const sessionId = await this.reporter.reportSession(session);
+                                this.setIndent(4)
+                                    .write(`* ${f.name} (${f.path})`)
+                                    .newline()
+                                    .setIndent(6)
+                                    .write(`* ${browserTestRun.browser}: ${this.chalk.blue.underline(this.reporter.getJobURL(sessionId))}`)
+                                    .newline()
+                                    .newline();
+                                resolve(sessionId);
+                            } catch (e) {
+                                // TODO: How to handle report failure?
+                            }
+                        })();
+                    });
+                }
+
+                return mappedRuns;
+            });
+
+            try {
+                await Promise.allSettled(reports);
+            } catch (e) {
+                // TODO: Handle failure?
+            }
+
+            // this.sauceTestReport.fixtures.forEach(async (fixture) => {
+            //     fixture.browserTestRuns.forEach(
+            //         async (browserTestRun, userAgent) => {
+            //             const jobUrl = await this.reporter.reportSession({
+            //                 name: fixture.path,
+            //                 startTime: fixture.startTime,
+            //                 endTime: fixture.endTime,
+            //                 testRun: browserTestRun.testRun,
+            //                 browserName: browserTestRun.browserName,
+            //                 browserVersion: browserTestRun.browserVersion,
+            //                 platformName: browserTestRun.platform,
+            //                 assets: browserTestRun.assets,
+            //                 userAgent: userAgent,
+            //             });
+
+            //             this.setIndent(4)
+            //                 .write(`* ${fixture.name} (${fixture.path})`)
+            //                 .newline()
+            //                 .setIndent(6)
+            //                 .write(`* ${browserTestRun.browser}: ${this.chalk.blue.underline(jobUrl)}`)
+            //                 .newline()
+            //                 .newline();
+            //         });
+            // });
+
         },
 
         taskDoneConsole (endTime, passed, warnings) {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -74,7 +74,6 @@ class Reporter {
 
         await this.uploadAssets(sessionId, assets);
 
-        // return this.getJobURL(sessionId);
         return sessionId;
     }
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 const SauceLabs = require('saucelabs').default;
 const { Status } = require('@saucelabs/sauce-json-reporter');
 const path = require('path');

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -74,7 +74,8 @@ class Reporter {
 
         await this.uploadAssets(sessionId, assets);
 
-        return this.getJobURL(sessionId);
+        // return this.getJobURL(sessionId);
+        return sessionId;
     }
 
     async createJob (body) {


### PR DESCRIPTION
Reporter output:

```
🍖 npx testcafe "chrome,firefox" tests/fixtures/sauceswag-ok/tests/sauceswag.ok.test.* --reporter="saucelabs"

Running tests in:
  - Chrome 97.0.4692.99 / macOS 10.15.7
  - Firefox 96.0 / macOS 10.15


    1) tests/fixtures/sauceswag-ok/tests/sauceswag.ok.test.js

      Getting Started Sauce demo
        ✓ SwagLabs username not set
        ✓ SwagLabs locked user login
        ✓ SwagLabs standard user login (screenshots:
        /Users/michaelhan/code/saucelabs/sauce-testcafe-runner/screenshots/2022-01-27_12-59-30/test-3)

      Sauce Labs Test Report
        * Firefox 96.0: https://app.saucelabs.com/tests/c52953bd4fa34400b6dffdd15b1174d8
        * Chrome 97.0.4692.99: https://app.saucelabs.com/tests/e7343ac3866945c79d53a5d2982a3cbc


    2) tests/fixtures/sauceswag-ok/tests/sauceswag.ok.test.ts

      Getting Started Sauce demo typescript
        ✓ SwagLabs username not set
        ✓ SwagLabs locked user login
        ✓ SwagLabs standard user login (screenshots:
        /Users/michaelhan/code/saucelabs/sauce-testcafe-runner/screenshots/2022-01-27_12-59-30/test-6)

      Sauce Labs Test Report
        * Firefox 96.0: https://app.saucelabs.com/tests/923d19d8ae194df198833684e569722b
        * Chrome 97.0.4692.99: https://app.saucelabs.com/tests/fb5864bee5534ffaaf23d588e32b8917


  6 passed (35s)
```

I've gone and made the logging to console functions a bit of a mess, but figured I'd leave it as is and we can come back to it to improve the overall logging experience. Would be nice in the future to add waiting indicators for the remote requests and stuff, just general terminal niceness.