### PR TITLE
[DEVX-2083] Submit to test-runs api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-lib
+dist
 node_modules
 screenshots

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,0 @@
-{
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2019"
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7068,6 +7068,12 @@
           "requires": {
             "os-tmpdir": "~1.0.1"
           }
+        },
+        "typescript": {
+          "version": "4.7.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+          "dev": true
         }
       }
     },
@@ -7537,9 +7543,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1816,9 +1816,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.0.tgz",
-      "integrity": "sha512-hsJgcqz4JY7f+HZ4cWTrPZ6tZNCNFPTRx1MjRqu/hbpgpHdSCUpLVuplc+jE/h7dOvyANtw/ERA3HC2Rz/QoMg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.4.tgz",
+      "integrity": "sha512-lIQuCfBJvZB/Bv7+RWUqEJqNShGOVpk9v7P0ZWx5Ip0qY6u7JBAU6dzQPMLasU9vHL2uD8av/1FDJXj7n6c39w==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -7722,6 +7722,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,6 +1487,15 @@
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/error-stack-parser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/error-stack-parser/-/error-stack-parser-2.0.0.tgz",
@@ -1532,6 +1541,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {
@@ -2431,10 +2446,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -5088,8 +5102,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mustache": {
       "version": "2.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1481,6 +1481,12 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
     "@types/error-stack-parser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/error-stack-parser/-/error-stack-parser-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "build": "tsc",
     "watch": "tsc -w",
     "lint": "eslint src/",
-    "release": "release-it --github.release",
-    "release:ci": "npm run release -- --ci --no-git.requireCleanWorkingDir",
+    "release": "tsc && release-it --github.release",
+    "release:ci": "tsc && npm run release -- --ci --no-git.requireCleanWorkingDir",
     "release:patch": "npm run release -- patch",
     "release:minor": "npm run release -- minor",
     "release:major": "npm run release -- major"

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "email": "devx@saucelabs.com",
     "url": "https://www.saucelabs.com"
   },
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "files": [
-    "src"
+    "dist"
   ],
   "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
     "lint": "eslint src/",
     "release": "release-it --github.release",
     "release:ci": "npm run release -- --ci --no-git.requireCleanWorkingDir",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
   "dependencies": {
     "@saucelabs/sauce-json-reporter": "^1.0.0",
     "@saucelabs/testcomposer": "^0.1.0",
-    "testcafe-reporter-sauce-json": "0.7.0"
+    "axios": "^1.2.4",
+    "debug": "^4.3.4",
+    "testcafe-reporter-sauce-json": "0.7.0",
+    "uuid": "^9.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@tsconfig/node14": "^1.0.3",
+    "@types/debug": "^4.1.7",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-node": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "release-it": "^15.5.0",
-    "testcafe": "^2.0.1"
+    "testcafe": "^2.0.1",
+    "typescript": "^4.9.5"
   },
   "peerDependencies": {
     "testcafe": "^1.0.1"

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,105 @@
+import * as util from 'util';
+import axios, {AxiosInstance, isAxiosError} from 'axios';
+import Debug from 'debug';
+
+const debug = Debug('testcafe-reporter-saucelabs:api');
+
+// The Sauce Labs region.
+export type Region = 'us-west-1' | 'eu-central-1' | 'staging';
+
+const apiURLMap = new Map<Region, string>([
+    ['us-west-1', 'https://api.us-west-1.saucelabs.com'],
+    ['eu-central-1', 'https://api.eu-central-1.saucelabs.com'],
+    ['staging', 'https://api.staging.saucelabs.net']
+  ]
+);
+
+interface CI {
+  ref_name?: string;
+  commit_sha?: string;
+  repository?: string;
+  branch?: string;
+}
+
+interface SauceJob {
+  id?: string;
+  name?: string;
+}
+
+export interface TestRunError {
+  message?: string;
+  path?: string;
+  line?: number;
+}
+
+// ISO_8601 (YYYY-MM-DDTHH:mm:ss.sssZ)
+type ISODate = string;
+
+export interface TestRunRequestBody {
+  id: string;
+  name: string;
+  start_time: ISODate;
+  end_time: ISODate;
+  duration: number;
+
+  user_id?: string;
+  team_id?: string;
+  group_id?: string;
+  author_id?: string;
+  path_name?: string;
+  build_id?: string;
+  build_name?: string;
+  creation_time?: ISODate;
+  browser?: string;
+  os?: string;
+  app_name?: string;
+  status?: 'passed' | 'failed' | 'skipped';
+  platform?: 'vdc' | 'rdc' | 'api' | 'other';
+  type?: 'web' | 'mobile' | 'api' | 'other';
+  framework?: string;
+  ci?: CI;
+  sauce_job?: SauceJob;
+  errors?: TestRunError[];
+  tags?: string[];
+}
+
+interface HTTPValidationError {
+  detail: { loc: string | number, msg: string, type: string }
+}
+
+export class TestRuns {
+  private api: AxiosInstance;
+
+  constructor(opts: { username: string, accessKey: string, region: Region}) {
+    this.api = axios.create({
+      auth: {
+        username: opts.username,
+        password: opts.accessKey,
+      },
+      baseURL: apiURLMap.get(opts.region),
+    });
+  }
+
+  async create(testRuns: TestRunRequestBody[]) {
+    try {
+      debug('Submitting test run to test-runs api', testRuns);
+      // await this.api.post<void>('/test-runs/v1/', {
+      //   test_runs: testRuns,
+      // });
+    } catch (e: unknown) {
+      if (isAxiosError(e)) {
+        let data;
+        switch (e.response?.status) {
+          case 422:
+            data = e.response?.data as HTTPValidationError;
+            debug('Failed to report test run data', util.inspect(data, { depth: null}));
+            break;
+          default:
+            debug('Unexpected http error while reporting test run data: %s', e.message);
+        }
+      } else {
+        debug('Unexpected error while reporting test run data', e);
+      }
+    }
+  }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -83,9 +83,9 @@ export class TestRuns {
   async create(testRuns: TestRunRequestBody[]) {
     try {
       debug('Submitting test run to test-runs api', testRuns);
-      // await this.api.post<void>('/test-runs/v1/', {
-      //   test_runs: testRuns,
-      // });
+      await this.api.post<void>('/test-runs/v1/', {
+        test_runs: testRuns,
+      });
     } catch (e: unknown) {
       if (isAxiosError(e)) {
         let data;

--- a/src/api.ts
+++ b/src/api.ts
@@ -95,7 +95,7 @@ export class TestRuns {
             debug('Failed to report test run data', util.inspect(data, { depth: null}));
             break;
           default:
-            debug('Unexpected http error while reporting test run data: %s', e.message);
+            debug('Unexpected http error while reporting test run data: %s', e);
         }
       } else {
         debug('Unexpected error while reporting test run data', e);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import * as util from 'util';
-import axios, {AxiosInstance, isAxiosError} from 'axios';
+import axios, {AxiosInstance, RawAxiosRequestHeaders, isAxiosError} from 'axios';
 import Debug from 'debug';
 
 const debug = Debug('testcafe-reporter-saucelabs:api');
@@ -70,13 +70,14 @@ interface HTTPValidationError {
 export class TestRuns {
   private api: AxiosInstance;
 
-  constructor(opts: { username: string, accessKey: string, region: Region}) {
+  constructor(opts: { username: string, accessKey: string, region: Region, headers?: RawAxiosRequestHeaders}) {
     this.api = axios.create({
       auth: {
         username: opts.username,
         password: opts.accessKey,
       },
       baseURL: apiURLMap.get(opts.region),
+      headers: opts.headers,
     });
   }
 

--- a/src/ci.ts
+++ b/src/ci.ts
@@ -1,0 +1,85 @@
+interface Provider {
+  matcher(): boolean;
+  ci: CI;
+}
+
+interface CI {
+  repo: string;
+  refName: string;
+  sha: string;
+  user: string;
+}
+
+const GITHUB = {
+  matcher: () => !!process.env.GITHUB_ACTIONS,
+  ci: {
+    repo: process.env.GITHUB_REPOSITORY ?? '',
+    refName: process.env.GITHUB_REF_NAME ?? '',
+    branch: process.env.GITHUB_HEAD_REF ?? '',
+    sha: process.env.GITHUB_SHA ?? '',
+    user: process.env.GITHUB_ACTOR ?? '',
+  },
+};
+
+const GITLAB = {
+  matcher: () => !!process.env.GITLAB_CI,
+  ci: {
+    repo: process.env.CI_PROJECT_PATH ?? '',
+    refName: process.env.CI_COMMIT_REF_NAME ?? '',
+    sha: process.env.CI_COMMIT_SHA ?? '',
+    user: process.env.GITLAB_USER_LOGIN ?? '',
+  },
+};
+
+const JENKINS = {
+  matcher: () => !!process.env.JENKINS_URL,
+  ci: {
+    repo: process.env.GIT_URL ?? '',
+    refName: process.env.GIT_BRANCH ?? '',
+    sha: process.env.GIT_COMMIT ?? '',
+    user: '',
+  },
+};
+
+const BITBUCKET = {
+  matcher: () => !!process.env.BITBUCKET_BUILD_NUMBER,
+  ci: {
+    repo: process.env.BITBUCKET_REPO_FULL_NAME ?? '',
+    refName: process.env.BITBUCKET_BRANCH ?? '',
+    sha: process.env.BITBUCKET_COMMIT ?? '',
+    user: process.env.BITBUCKET_STEP_TRIGGERER_UUID ?? '',
+  },
+};
+
+const CIRCLECI = {
+  matcher: () => !!process.env.CIRCLECI,
+  ci: {
+    repo: process.env.CIRCLE_REPOSITORY_URL ?? '',
+    refName: process.env.CIRCLE_BRANCH ?? '',
+    sha: process.env.CIRCLE_SHA1 ?? '',
+    user: process.env.CIRCLE_USERNAME ?? '',
+  },
+};
+
+const DEFAULT = {
+  matcher: () => true,
+  ci: {
+    repo: '',
+    refName: '',
+    sha: '',
+    user: '',
+  },
+};
+
+const providers : Provider[] = [
+  GITHUB,
+  GITLAB,
+  JENKINS,
+  BITBUCKET,
+  CIRCLECI,
+];
+
+const provider = providers.find((p) => p.matcher());
+
+export const IS_CI = typeof(provider) !== 'undefined';
+export const CI = provider?.ci ?? DEFAULT.ci;

--- a/src/index.js
+++ b/src/index.js
@@ -62,10 +62,11 @@ module.exports = function () {
                         };
                         try {
                             const job = await this.reporter.reportSession(session);
-                            await this.reporter.reportTestRun(fixture, job.id);
                             this.setIndent(this.indentWidth * 4)
                                 .write(`* ${browserTestRun.browser}: ${this.chalk.blue.underline(job.url)}`)
                                 .newline();
+
+                            await this.reporter.reportTestRun(fixture, job.id);
                             resolve(job.id);
                         } catch (e) {
                             reject(e);

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ module.exports = function () {
                                 .write(`* ${browserTestRun.browser}: ${this.chalk.blue.underline(job.url)}`)
                                 .newline();
 
-                            await this.reporter.reportTestRun(fixture, job.id);
+                            await this.reporter.reportTestRun(fixture, browserTestRun, job.id);
                             resolve(job.id);
                         } catch (e) {
                             reject(e);

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ module.exports = function () {
                         const session = {
                             name: fixture.path,
                             startTime: fixture.startTime,
-                            endTime: fixture.endTime ?? new Date(),
+                            endTime: new Date(),
                             testRun: browserTestRun.testRun,
                             browserName: browserTestRun.browserName,
                             browserVersion: browserTestRun.browserVersion,

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ module.exports = function () {
                         };
                         try {
                             const job = await this.reporter.reportSession(session);
-                            await this.reporter.reportTestRun(fixture, browserTestRun, job.id);
+                            await this.reporter.reportTestRun(fixture, job.id);
                             this.setIndent(this.indentWidth * 4)
                                 .write(`* ${browserTestRun.browser}: ${this.chalk.blue.underline(job.url)}`)
                                 .newline();

--- a/src/index.js
+++ b/src/index.js
@@ -83,8 +83,7 @@ module.exports = function () {
 
             if (this.specPath && this.specPath !== specPath) {
                 // End of currently running spec
-                const completedFixture = this.sauceTestReport.fixtures.find((f) => f.path === this.specPath);
-                console.log(completedFixture);
+                const completedFixture = this.sauceTestReport.fixtures.find((f) => f.path === path.relative(process.cwd(), this.specPath));
                 await this.reportFixture(completedFixture);
             }
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -30,7 +30,7 @@ class Reporter {
             region: opts.region || Region.USWest1,
             username: this.username,
             accessKey: this.accessKey,
-            headers: {'User-Agent': `cypress-reporter/${reporterVersion}`}
+            headers: {'User-Agent': `testcafe-reporter/${reporterVersion}`}
         });
 
         this.testRunsAPI = new TestRunsAPI({

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -26,17 +26,21 @@ class Reporter {
         this.tags = opts.tags;
         this.region = opts.region || 'us-west-1';
 
+        const userAgent = `testcafe-reporter/${reporterVersion}`;
         this.testComposer = new TestComposer({
             region: opts.region || Region.USWest1,
             username: this.username,
             accessKey: this.accessKey,
-            headers: {'User-Agent': `testcafe-reporter/${reporterVersion}`}
+            headers: {'User-Agent': userAgent }
         });
 
         this.testRunsAPI = new TestRunsAPI({
             region: opts.region || Region.USWest1,
             username: this.username,
             accessKey: this.accessKey,
+            headers: {
+                'User-Agent': userAgent,
+            },
         });
     }
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -46,7 +46,8 @@ class Reporter {
 
     /**
      * Reports a fixture from testcafe-reporter-sauce-json/reporter to the test-runs api.
-     * @param {?} fixture
+     * @param {?} fixture - A Fixture object from the testcafe-reporter-sauce-json/reporter package
+     * @param {?} browserTestRun - A BrowserTestRun object from the testcafe-reporter-sauce-json/reporter package
      * @param {string} jobId
      */
     async reportTestRun (fixture, browserTestRun, jobId) {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,13 +1,12 @@
-const { Status, TestRun, Suite, Test } = require('@saucelabs/sauce-json-reporter');
+const { Status, Test } = require('@saucelabs/sauce-json-reporter');
 const path = require('path');
 const fs = require('fs');
 const stream = require('stream');
 const { v4: uuidv4 } = require('uuid');
 const crypto = require('crypto');
-const { Fixture } = require('testcafe-reporter-sauce-json/fixture');
-import { Region, TestComposer } from '@saucelabs/testcomposer';
-import { TestRuns as TestRunsAPI } from './api';
-import { CI } from './ci';
+const { Region, TestComposer } = require('@saucelabs/testcomposer');
+const { TestRuns: TestRunsAPI } = require('./api');
+const { CI } = require('./ci');
 
 class Reporter {
     constructor (logger = console, opts = {}) {
@@ -51,7 +50,7 @@ class Reporter {
     async reportTestRun (fixture, jobId) {
         const baseRun = {
             start_time: fixture.startTime.toISOString(),
-            end_time: fixture.endTime?.toISOString() || new Date().toISOString(),
+            end_time: (fixture.endTime && fixture.endTime.toISOString()) || new Date().toISOString(),
             path_name: fixture.path,
             platform: 'other',
             type: 'web',
@@ -73,7 +72,7 @@ class Reporter {
         let reqs = [];
         const browserTestRuns = [...fixture.browserTestRuns.values()];
         browserTestRuns.forEach((browserTestRun) => {
-            /** @type TestRun */
+            /** @type {typeof import('@saucelabs/sauce-json-reporter).TestRun} */
             const testRun = browserTestRun.testRun;
             const tests = this.findTests(testRun.suites[0].suites);
             reqs = reqs.concat(tests.map((test) => {
@@ -93,7 +92,7 @@ class Reporter {
     }
 
     /**
-     * Recurses through suites and returns a flattened list of tests
+     * Recurses through suites and returns a flattened list of tests.
      * @param {Suite[]} suites
      * @param {string[]} names
      * @returns {Test[]}

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,10 +1,11 @@
-const { Status, Test } = require('@saucelabs/sauce-json-reporter');
-const path = require('path');
+const crypto = require('crypto');
 const fs = require('fs');
+const path = require('path');
 const stream = require('stream');
 const { v4: uuidv4 } = require('uuid');
-const crypto = require('crypto');
+const { Status, Test } = require('@saucelabs/sauce-json-reporter');
 const { Region, TestComposer } = require('@saucelabs/testcomposer');
+
 const { TestRuns: TestRunsAPI } = require('./api');
 const { CI } = require('./ci');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true
+  },
+  "include": ["./src/**/*"]
+}


### PR DESCRIPTION
* Report specs to test-runs api. We rely on the inner workings of the underlying `testcafe-reporter-sauce-json` package to manage the insanity of testcafe reporting.
* Reported errors is missing the line number property. Easiest way to add it would be to enhance the `testcafe-reporter-sauce-json` reporter to track the additional metadata.
* Introduce ts build step
