### PR TITLE
fix: Update package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "testcafe-reporter-saucelabs",
-      "version": "0.5.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "^1.0.0",
@@ -29,7 +29,7 @@
         "typescript": "^4.9.5"
       },
       "peerDependencies": {
-        "testcafe": "^1.0.1"
+        "testcafe": ">=1.0.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "dist/src/index.js",
   "files": [
-    "dist"
+    "dist/src"
   ],
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "devx@saucelabs.com",
     "url": "https://www.saucelabs.com"
   },
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "files": [
     "dist"
   ],
@@ -44,7 +44,7 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "testcafe": "^1.0.1"
+    "testcafe": ">=1.0.1"
   },
   "dependencies": {
     "@saucelabs/sauce-json-reporter": "^1.0.0",


### PR DESCRIPTION
- Makes `main` (`package.json` point to `dist/src/index.js` instead of `dist/index.js` (makes `import/require()` failing)
- Makes `peerDependencies` to tolerate any version of TestCafe above `1.0.1` (makes `npm ci` failing)