### PR TITLE
chore!: Maintenance Update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[{.eslintrc,*.json,.travis.yml}]
+[{.eslintrc,*.json,.travis.yml,.github/**/*}]
 indent_size = 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,41 @@
-name: Release New Version
+name: Release
 
 on:
-    workflow_dispatch:
-        inputs:
-            releaseType:
-                description: 'Release type - major, minor or patch'
-                required: false
-                default: 'patch'
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Release type - major, minor or patch'
+        required: false
+        default: 'patch'
 
 jobs:
-    publish-release:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-              with:
-                  ref: ${{ github.ref }}
-                  fetch-depth: 0
+  publish-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
 
-            - name: Setup Node version
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 14
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
 
-            - name: Install dependencies
-              run: npm ci
+      - name: Install Dependencies
+        run: npm ci
 
-            - name: Setup Git
-              run: |
-                  git config --global user.name "devx-sauce-bot"
-                  git config --global user.email "devx.bot@saucelabs.com"
+      - name: Setup Git
+        run: |
+          git config --global user.name "devx-sauce-bot"
+          git config --global user.email "devx.bot@saucelabs.com"
 
-            - name: Login to NPM
-              run: npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}
+      - name: Setup NPM
+        run: npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}
 
-            - name: Release
-              run: npm run release:ci -- ${{ github.event.inputs.releaseType }}
-              env:
-                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-                  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Release
+        run: npm run release:ci -- ${{ github.event.inputs.releaseType }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Test
 
 on:
   pull_request:
@@ -15,13 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Install deps
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Dependencies
         run: npm i
 
-      - name: Build Typescript Code
+      - name: Build
         run: npm run build
 
-      - name: Run tests
+      - name: Test
         run: npm run test

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+v18

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ against Sauce Labs, then refrain from installing this reporter, as you will be c
 npm install testcafe-reporter-saucelabs
 ```
 
-**Requirement**: Node.js 14 or higher.
+**Requirement**: Node.js 18 or higher.
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "jest": "^29.5.0",
         "release-it": "^15.5.0",
         "testcafe": "^2.0.1",
-        "typescript": "^4.9.5"
+        "typescript": "5.1.3"
       },
       "peerDependencies": {
         "testcafe": ">=1.0.1"
@@ -14208,16 +14208,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -24974,9 +24973,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "ts-jest": "^29.0.5"
       },
       "devDependencies": {
-        "@tsconfig/node14": "^1.0.3",
+        "@tsconfig/node18": "2.0.1",
         "@types/debug": "^4.1.7",
         "@types/jest": "^29.4.0",
         "eslint": "^7.32.0",
@@ -2991,12 +2991,11 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/@tsconfig/node18": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-2.0.1.tgz",
+      "integrity": "sha512-UqdfvuJK0SArA2CxhKWwwAWfnVSXiYe63bVpMutc27vpngCntGUZQETO24pEJ46zU6XM+7SpqYoMgcO3bM11Ew==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
@@ -17003,10 +17002,10 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+    "@tsconfig/node18": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-2.0.1.tgz",
+      "integrity": "sha512-UqdfvuJK0SArA2CxhKWwwAWfnVSXiYe63bVpMutc27vpngCntGUZQETO24pEJ46zU6XM+7SpqYoMgcO3bM11Ew==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@saucelabs/sauce-json-reporter": "^1.0.0",
-        "@saucelabs/testcomposer": "^0.1.0",
+        "@saucelabs/sauce-json-reporter": "2.0.0",
+        "@saucelabs/testcomposer": "1.0.0",
         "axios": "^1.2.4",
         "debug": "^4.3.4",
         "ts-jest": "^29.0.5"
@@ -2919,16 +2919,14 @@
       }
     },
     "node_modules/@saucelabs/sauce-json-reporter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-1.1.0.tgz",
-      "integrity": "sha512-AZcdE6bs6ENEcczUwqAZQ1/5XUKY7XdvCOYNw0bh9Py82c4z3BZv3gorejZRxdsgboFhNvmt3P8M3WpKa6ZIrA==",
-      "license": "MIT"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-2.0.0.tgz",
+      "integrity": "sha512-iqWznoFNxPLYI/IUDVWf13EgjPEh/zDuyibCnoyPfa0yw8QHQNltUwfvsf7zo6kTT06m434pyolYau187EwX6A=="
     },
     "node_modules/@saucelabs/testcomposer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@saucelabs/testcomposer/-/testcomposer-0.1.0.tgz",
-      "integrity": "sha512-piowZOFTawP6qMZAzlH3VHNSMBbX7XdUyjTsMXtqFoZGhd/iIvXporAc6cJIkizi/cnNEz7u86o8d/UFM0iEAg==",
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@saucelabs/testcomposer/-/testcomposer-1.0.0.tgz",
+      "integrity": "sha512-a31uqfGDihfIXKzyzWzg+zWCoprbjTmFnhgA1+TSbwLavGx3sfDECE7jPC12LMtKp0QkdCTQ81R04amkxGmcMw==",
       "dependencies": {
         "axios": "^1.0.0",
         "form-data": "^4.0.0"
@@ -16946,14 +16944,14 @@
       }
     },
     "@saucelabs/sauce-json-reporter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-1.1.0.tgz",
-      "integrity": "sha512-AZcdE6bs6ENEcczUwqAZQ1/5XUKY7XdvCOYNw0bh9Py82c4z3BZv3gorejZRxdsgboFhNvmt3P8M3WpKa6ZIrA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-2.0.0.tgz",
+      "integrity": "sha512-iqWznoFNxPLYI/IUDVWf13EgjPEh/zDuyibCnoyPfa0yw8QHQNltUwfvsf7zo6kTT06m434pyolYau187EwX6A=="
     },
     "@saucelabs/testcomposer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@saucelabs/testcomposer/-/testcomposer-0.1.0.tgz",
-      "integrity": "sha512-piowZOFTawP6qMZAzlH3VHNSMBbX7XdUyjTsMXtqFoZGhd/iIvXporAc6cJIkizi/cnNEz7u86o8d/UFM0iEAg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@saucelabs/testcomposer/-/testcomposer-1.0.0.tgz",
+      "integrity": "sha512-a31uqfGDihfIXKzyzWzg+zWCoprbjTmFnhgA1+TSbwLavGx3sfDECE7jPC12LMtKp0QkdCTQ81R04amkxGmcMw==",
       "requires": {
         "axios": "^1.0.0",
         "form-data": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@tsconfig/node14": "^1.0.3",
+    "@tsconfig/node18": "2.0.1",
     "@types/debug": "^4.1.7",
     "@types/jest": "^29.4.0",
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "testcafe": ">=1.0.1"
   },
   "dependencies": {
-    "@saucelabs/sauce-json-reporter": "^1.0.0",
-    "@saucelabs/testcomposer": "^0.1.0",
+    "@saucelabs/sauce-json-reporter": "2.0.0",
+    "@saucelabs/testcomposer": "1.0.0",
     "axios": "^1.2.4",
     "debug": "^4.3.4",
     "ts-jest": "^29.0.5"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jest": "^29.5.0",
     "release-it": "^15.5.0",
     "testcafe": "^2.0.1",
-    "typescript": "^4.9.5"
+    "typescript": "5.1.3"
   },
   "peerDependencies": {
     "testcafe": ">=1.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
-const { SauceJsonReporter } = require('./json-reporter');
-const { JobReporter } = require('./job-reporter');
+const {SauceJsonReporter} = require('./json-reporter');
+const {JobReporter} = require('./job-reporter');
 
 module.exports = function () {
     return {
@@ -12,16 +12,16 @@ module.exports = function () {
         disableUpload: process.env.SAUCE_DISABLE_UPLOAD !== undefined,
 
         // JobReporter
-        indentWidth:    2,
-        specPath:       '',
-        relSpecPath:    '',
-        fixtureName:    '',
+        indentWidth: 2,
+        specPath: '',
+        relSpecPath: '',
+        fixtureName: '',
         afterErrorList: false,
-        startTime:      null,
-        startTimes:     new Map(),
+        startTime: null,
+        startTimes: new Map(),
 
         // TestCafe Hooks
-        reportTaskStart: async function(startTime, userAgents, testCount, testStructure, properties) {
+        reportTaskStart: async function (startTime, userAgents, testCount, testStructure, properties) {
             this.sauceJsonReporter.reportTaskStart(startTime, userAgents, testCount);
 
             if (this.disableUpload) {
@@ -34,7 +34,7 @@ module.exports = function () {
             this.taskStartConsole(startTime, userAgents, testCount);
         },
 
-        reportFixtureStart: async function(name, specPath, meta) {
+        reportFixtureStart: async function (name, specPath, meta) {
             this.sauceJsonReporter.reportFixtureStart(name, specPath, meta);
 
             if (this.disableUpload) {
@@ -54,7 +54,7 @@ module.exports = function () {
             this.fixtureStartConsole(name, specPath, meta);
         },
 
-        reportTestStart: async function(name, meta, testStartInfo) {
+        reportTestStart: async function (name, meta, testStartInfo) {
             this.sauceJsonReporter.reportTestStart(name, meta, testStartInfo);
 
             if (this.disableUpload) {
@@ -64,7 +64,7 @@ module.exports = function () {
             this.startTimes.set(testStartInfo.testId, new Date());
         },
 
-        reportTestDone: async function(name, testRunInfo, meta) {
+        reportTestDone: async function (name, testRunInfo, meta) {
             this.sauceJsonReporter.reportTestDone(name, testRunInfo, meta);
 
             if (this.disableUpload) {
@@ -74,7 +74,7 @@ module.exports = function () {
             this.testDoneConsole(name, testRunInfo, meta);
         },
 
-        reportTaskDone: async function(endTime, passed, warnings, result) {
+        reportTaskDone: async function (endTime, passed, warnings, result) {
             this.sauceJsonReporter.reportTaskDone(endTime, passed, warnings, result);
             const mergedTestRun = this.sauceJsonReporter.mergeTestRuns();
 
@@ -90,7 +90,7 @@ module.exports = function () {
         },
 
         // Extraneous funcs - Used by JobReporter
-        taskStartConsole (startTime, userAgents, testCount) {
+        taskStartConsole(startTime, userAgents, testCount) {
             this.setIndent(this.indentWidth)
                 .newline()
                 .useWordWrap(true)
@@ -105,7 +105,10 @@ module.exports = function () {
         },
 
         async reportFixture(fixture) {
-            // TODO check if user account is set up for reporting; if not, log the skip
+            if (!this.reporter.isAccountSet()) {
+                return;
+            }
+
             this.setIndent(this.indentWidth * 3)
                 .newline()
                 .write(this.chalk.bold.underline('Sauce Labs Test Report'))
@@ -145,7 +148,7 @@ module.exports = function () {
             this.newline();
         },
 
-        specStartConsole (relSpecPath, index) {
+        specStartConsole(relSpecPath, index) {
             this.newline()
                 .setIndent(this.indentWidth * 2)
                 .useWordWrap(true)
@@ -153,14 +156,13 @@ module.exports = function () {
                 .newline();
         },
 
-        fixtureStartConsole (name, specPath, meta) {
+        fixtureStartConsole(name, specPath, meta) {
             this.setIndent(this.indentWidth)
                 .useWordWrap(true);
 
             if (this.afterErrorList) {
                 this.afterErrorList = false;
-            }
-            else {
+            } else {
                 this.newline();
             }
 
@@ -168,7 +170,7 @@ module.exports = function () {
                 .newline();
         },
 
-        testDoneConsole (name, testRunInfo, meta) {
+        testDoneConsole(name, testRunInfo, meta) {
             const hasErr = !!testRunInfo.errs.length;
             let symbol = null;
             let nameStyle = null;
@@ -178,14 +180,10 @@ module.exports = function () {
 
                 symbol = this.chalk.cyan('-');
                 nameStyle = this.chalk.cyan;
-            }
-
-            else if (hasErr) {
+            } else if (hasErr) {
                 symbol = this.chalk.red.bold(this.symbols.err);
                 nameStyle = this.chalk.red.bold;
-            }
-
-            else {
+            } else {
                 symbol = this.chalk.green(this.symbols.ok);
                 nameStyle = this.chalk.grey;
             }
@@ -216,7 +214,7 @@ module.exports = function () {
             this.newline();
         },
 
-        taskDoneConsole (endTime, passed, warnings) {
+        taskDoneConsole(endTime, passed, warnings) {
             const durationMs = endTime - this.startTime;
             const durationStr = this.moment.duration(durationMs).format('h[h] mm[m] ss[s]');
             let footer = passed === this.testCount ?
@@ -245,7 +243,7 @@ module.exports = function () {
         },
 
 
-        _renderReportData (reportData, browsers, name, testRunInfo, meta) {
+        _renderReportData(reportData, browsers, name, testRunInfo, meta) {
             if (!reportData)
                 return;
 
@@ -253,13 +251,13 @@ module.exports = function () {
                 return;
 
             const renderBrowserName = browsers.length > 1;
-            const dataIndent        = browsers.length > 1 ? 3 : 2;
+            const dataIndent = browsers.length > 1 ? 3 : 2;
 
             this.newline()
                 .setIndent(this.indentWidth)
                 .write('Report data:');
 
-            browsers.forEach(({ testRunId, prettyUserAgent }) => {
+            browsers.forEach(({testRunId, prettyUserAgent}) => {
                 const browserReportData = reportData[testRunId];
 
                 if (!browserReportData)
@@ -279,7 +277,7 @@ module.exports = function () {
             });
         },
 
-        _renderErrors (errs, name, testRunInfo, meta) {
+        _renderErrors(errs, name, testRunInfo, meta) {
             this.setIndent(this.indentWidth * 3)
                 .newline();
 
@@ -293,7 +291,7 @@ module.exports = function () {
             });
         },
 
-        _renderWarnings (warnings) {
+        _renderWarnings(warnings) {
             this.newline()
                 .setIndent(this.indentWidth * 4)
                 .write(this.chalk.bold.yellow(`Warnings (${warnings.length}):`))
@@ -309,11 +307,11 @@ module.exports = function () {
             });
         },
 
-        log (msg) {
+        log(msg) {
             this.write(msg).newline();
         },
 
-        error (msg) {
+        error(msg) {
             this.newline()
                 .write(this.chalk.red(msg))
                 .newline();

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ module.exports = function () {
         startTimes:     new Map(),
 
         // TestCafe Hooks
-        reportTaskStart: async function(startTime, userAgents, testCount, testStructure, properties) {            
+        reportTaskStart: async function(startTime, userAgents, testCount, testStructure, properties) {
             this.sauceJsonReporter.reportTaskStart(startTime, userAgents, testCount);
 
             if (this.disableUpload) {
@@ -31,7 +31,7 @@ module.exports = function () {
             this.reporter = new JobReporter(this, properties.configuration.sauce);
             this.startTime = startTime;
             this.testCount = testCount;
-            this.taskStartConsole(userAgents);
+            this.taskStartConsole(startTime, userAgents, testCount);
         },
 
         reportFixtureStart: async function(name, specPath, meta) {
@@ -51,7 +51,7 @@ module.exports = function () {
             this.relSpecPath = path.relative(process.cwd(), this.specPath);
             this.specStartConsole(this.relSpecPath, this.sauceJsonReporter.fixtures.length);
 
-            this.fixtureStartConsole(name);
+            this.fixtureStartConsole(name, specPath, meta);
         },
 
         reportTestStart: async function(name, meta, testStartInfo) {
@@ -71,7 +71,7 @@ module.exports = function () {
                 return;
             }
 
-            this.testDoneConsole(name, testRunInfo);
+            this.testDoneConsole(name, testRunInfo, meta);
         },
 
         reportTaskDone: async function(endTime, passed, warnings, result) {
@@ -90,22 +90,22 @@ module.exports = function () {
         },
 
         // Extraneous funcs - Used by JobReporter
-        taskStartConsole (userAgents) {
-            this.newline()
+        taskStartConsole (startTime, userAgents, testCount) {
+            this.setIndent(this.indentWidth)
+                .newline()
                 .useWordWrap(true)
-                .write(this.chalk.bold('Running tests in:'))
+                .write(this.chalk.bold('Running tests in:'), startTime, userAgents, testCount)
                 .newline();
 
             userAgents.forEach(ua => {
-                this.setIndent(this.indentWidth)
-                    .write(`- ${this.chalk.cyan(ua)}`)
+                this
+                    .write(`- ${this.chalk.blue(ua)}`, startTime, userAgents, testCount)
                     .newline();
             });
-
-            this.newline();
         },
 
         async reportFixture(fixture) {
+            // TODO check if user account is set up for reporting; if not, log the skip
             this.setIndent(this.indentWidth * 3)
                 .newline()
                 .write(this.chalk.bold.underline('Sauce Labs Test Report'))
@@ -153,8 +153,8 @@ module.exports = function () {
                 .newline();
         },
 
-        fixtureStartConsole (name) {
-            this.setIndent(this.indentWidth * 3)
+        fixtureStartConsole (name, specPath, meta) {
+            this.setIndent(this.indentWidth)
                 .useWordWrap(true);
 
             if (this.afterErrorList) {
@@ -164,11 +164,11 @@ module.exports = function () {
                 this.newline();
             }
 
-            this.write(name)
+            this.write(name, specPath, meta)
                 .newline();
         },
 
-        testDoneConsole (name, testRunInfo) {
+        testDoneConsole (name, testRunInfo, meta) {
             const hasErr = !!testRunInfo.errs.length;
             let symbol = null;
             let nameStyle = null;
@@ -189,10 +189,10 @@ module.exports = function () {
                 symbol = this.chalk.green(this.symbols.ok);
                 nameStyle = this.chalk.grey;
             }
-            const styledName = nameStyle(`${name} (${testRunInfo.durationMs}ms)`);
-            let title = `${symbol} ${styledName}`;
+            // const styledName = nameStyle(`${name} (${testRunInfo.durationMs}ms)`);
+            let title = `${symbol} ${nameStyle(name)} (${testRunInfo.durationMs}ms)`;
 
-            this.setIndent(this.indentWidth * 4)
+            this.setIndent(this.indentWidth)
                 .useWordWrap(true);
 
             if (testRunInfo.unstable) {
@@ -203,10 +203,12 @@ module.exports = function () {
                 title += ` (screenshots: ${this.chalk.underline.grey(testRunInfo.screenshotPath)})`;
             }
 
-            this.write(title);
+            this.write(title, name, testRunInfo, meta);
+
+            this._renderReportData(testRunInfo.reportData, name, testRunInfo, meta);
 
             if (hasErr) {
-                this._renderErrors(testRunInfo.errs);
+                this._renderErrors(testRunInfo.errs, name, testRunInfo, meta);
             }
 
             this.afterErrorList = hasErr;
@@ -242,15 +244,50 @@ module.exports = function () {
             }
         },
 
-        _renderErrors (errs) {
-            this.setIndent(this.indentWidth * 4)
+
+        _renderReportData (reportData, browsers, name, testRunInfo, meta) {
+            if (!reportData)
+                return;
+
+            if (!Object.values(reportData).some(data => data.length))
+                return;
+
+            const renderBrowserName = browsers.length > 1;
+            const dataIndent        = browsers.length > 1 ? 3 : 2;
+
+            this.newline()
+                .setIndent(this.indentWidth)
+                .write('Report data:');
+
+            browsers.forEach(({ testRunId, prettyUserAgent }) => {
+                const browserReportData = reportData[testRunId];
+
+                if (!browserReportData)
+                    return;
+
+                if (renderBrowserName) {
+                    this.setIndent(this.indentWidth * 2)
+                        .newline()
+                        .write(prettyUserAgent, name, testRunInfo, meta);
+                }
+
+                browserReportData.forEach(data => {
+                    this.setIndent(this.indentWidth * dataIndent)
+                        .newline()
+                        .write(`- ${data}`, name, testRunInfo, meta);
+                });
+            });
+        },
+
+        _renderErrors (errs, name, testRunInfo, meta) {
+            this.setIndent(this.indentWidth * 3)
                 .newline();
 
             errs.forEach((err, idx) => {
                 const prefix = this.chalk.red(`${idx + 1}) `);
 
                 this.newline()
-                    .write(this.formatError(err, prefix))
+                    .write(this.formatError(err, prefix), name, testRunInfo, meta)
                     .newline()
                     .newline();
             });

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const {JobReporter} = require('./job-reporter');
 
 module.exports = function () {
     return {
-        noColors: true,
+        noColors: !!process.env.SAUCE_NO_COLORS || !!process.env.SAUCE_VM,
         sauceJsonReporter: SauceJsonReporter.newReporter(),
 
         sauceReportJsonPath: process.env.SAUCE_REPORT_JSON_PATH || './sauce-test-report.json',
@@ -15,7 +15,6 @@ module.exports = function () {
         indentWidth: 2,
         specPath: '',
         relSpecPath: '',
-        fixtureName: '',
         afterErrorList: false,
         startTime: null,
         startTimes: new Map(),

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,6 @@ module.exports = function () {
                 symbol = this.chalk.green(this.symbols.ok);
                 nameStyle = this.chalk.grey;
             }
-            // const styledName = nameStyle(`${name} (${testRunInfo.durationMs}ms)`);
             let title = `${symbol} ${nameStyle(name)} (${testRunInfo.durationMs}ms)`;
 
             this.setIndent(this.indentWidth)

--- a/src/job-reporter.js
+++ b/src/job-reporter.js
@@ -27,7 +27,7 @@ class JobReporter {
 
         const userAgent = `testcafe-reporter/${reporterVersion}`;
         this.testComposer = new TestComposer({
-            region: opts.region || this.region,
+            region: this.region,
             username: this.username,
             accessKey: this.accessKey,
             headers: {'User-Agent': userAgent }

--- a/src/job-reporter.js
+++ b/src/job-reporter.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
 const { Status, Test } = require('@saucelabs/sauce-json-reporter');
-const { Region, TestComposer } = require('@saucelabs/testcomposer');
+const { TestComposer } = require('@saucelabs/testcomposer');
 
 const { TestRuns: TestRunsAPI } = require('./api');
 const { CI } = require('./ci');
@@ -27,14 +27,14 @@ class JobReporter {
 
         const userAgent = `testcafe-reporter/${reporterVersion}`;
         this.testComposer = new TestComposer({
-            region: opts.region || Region.USWest1,
+            region: opts.region || this.region,
             username: this.username,
             accessKey: this.accessKey,
             headers: {'User-Agent': userAgent }
         });
 
         this.testRunsAPI = new TestRunsAPI({
-            region: opts.region || Region.USWest1,
+            region: this.region,
             username: this.username,
             accessKey: this.accessKey,
             headers: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
     "allowJs": true


### PR DESCRIPTION
- Breaking Change: Require Node 18 (up from 14)
- Bump dependencies
- Clean up pipeline
- Incorporate minor changes from the official [testcafe spec reporter](https://github.com/DevExpress/testcafe-reporter-spec/blob/master/src/index.js)
- Allow colored output except on sauce VMs