### PR TITLE
fix: Missing version in User-Agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "email": "devx@saucelabs.com",
     "url": "https://www.saucelabs.com"
   },
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "files": [
-    "dist/src"
+    "dist/"
   ],
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "./dist",
     "allowJs": true
   },
-  "include": ["./src/**/*", "./tests/**/*"]
+  "include": ["./src/**/*"]
 }


### PR DESCRIPTION
The code responsible for retrieving the version is:
```javascript
        let reporterVersion = 'unknown';
        try {
            const packageData = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
            reporterVersion = packageData.version;
        } catch (e) {
        }
```

However, the packaged module is:
![Screenshot 2023-06-07 at 3 04 37 PM](https://github.com/saucelabs/testcafe-reporter/assets/1869292/e3f3e9eb-e0bf-47dd-91a4-2ae3fac6ba3a)

`package.json` is sitting outside of the dist folder. See https://www.npmjs.com/package/testcafe-reporter-saucelabs?activeTab=code

Instead of changing the code though, I opted to remove the typescript compiler inclusion of tests, since it's not necessary, because `ts-jest` already handles typescript compilation.

Coincidentally, typescript's compiler flattens the output directory when only one source is included:
![Screenshot 2023-06-07 at 3 04 02 PM](https://github.com/saucelabs/testcafe-reporter/assets/1869292/a62a522b-6741-49ef-a706-27d3ce1da78f)