### PR TITLE
feat: Print links to assets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,6 +134,14 @@ module.exports = function () {
                                 .write(`* ${browserTestRun.browser}: ${this.chalk.blue.underline(job.url)}`)
                                 .newline();
 
+                            if (job.assets.length > 0) {
+                                this.write(`  ${this.chalk.bold('Assets:')}`)
+                                    .newline();
+                            }
+                            for (const asset of job.assets) {
+                                this.write(`    - ${this.chalk.blue.underline(asset)}`);
+                            }
+
                             await this.reporter.reportTestRun(fixture, browserTestRun, job.id);
                             resolve(job.id);
                         } catch (e) {

--- a/src/job-reporter.js
+++ b/src/job-reporter.js
@@ -8,6 +8,12 @@ const { TestComposer } = require('@saucelabs/testcomposer');
 const { TestRuns: TestRunsAPI } = require('./api');
 const { CI } = require('./ci');
 
+const assetsURLMap = new Map([
+    ['us-west-1', 'https://assets.saucelabs.com'],
+    ['eu-central-1', 'https://assets.eu-central-1.saucelabs.com'],
+    ['staging', 'https://assets.staging.saucelabs.net']
+]);
+
 class JobReporter {
     constructor (logger = console, opts = {}) {
         this.log = logger;
@@ -147,8 +153,12 @@ class JobReporter {
             browserVersion:   session.browserVersion,
             platformName:     session.platformName,
         });
+        job.assets = [];
+        const baseURL = assetsURLMap.get(this.region);
 
         const assets = session.assets.map((a) => {
+            job.assets.push(`${baseURL}/jobs/${job.id}/${a.name}`);
+
             return {
                 filename: a.name,
                 data: fs.createReadStream(a.localPath)


### PR DESCRIPTION
To improve the UX by speeding up user workflow of getting to assets, a list of uploaded assets is now printed out directly in the console.

_Architecturally_ it'd be better if the test-composer lib was the one returning the asset URLs for the reporter the print out. That'd also be consistent with that it does with the job URL.
Since this change is somewhat experimental in nature (the target audience being ourselves), I'm taking a shortcut by keeping the changes local within this testcafe reporter. Should this feature remain permanently (or even be included in the other reporters), I shall move that logic over to test-composer.