### PR TITLE
feat: Attach test run report to job if fixture was executed remotely

### DIFF
--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -24,11 +24,11 @@ export class BrowserTestRun {
     // NOTE: example userAgents:
     // * Chrome 126.0.0.0 / Sonoma 14
     // * Chrome 126.0.0.0 / Windows 10 (https://app.saucelabs.com/tests/000aa4ffc86d40bdbeebfcf165dab402)
-    const matches = userAgent.match(/^([\w\s.]+)\/([\w\s.]+)/);
+    const matches = userAgent.match(/^([\w .]+)(?:\/([\w .]+))?/);
 
-    if (matches && matches.length >= 2) {
-      this.#browser = matches[1].trim();
-      this.platform = matches[2].trim();
+    if (matches) {
+      this.#browser = matches[1]?.trim() ?? '';
+      this.platform = matches[2]?.trim() ?? '';
     } else {
       this.#browser = '';
       this.platform = '';

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const { JobReporter } = require('./job-reporter');
  * @typedef {import("./fixture").Fixture} Fixture
  */
 
-module.exports = function() {
+module.exports = function () {
   return {
     noColors: !!process.env.SAUCE_NO_COLORS || !!process.env.SAUCE_VM,
     sauceJsonReporter: SauceJsonReporter.newReporter(),
@@ -93,7 +93,7 @@ module.exports = function() {
       this.testDoneConsole(name, testRunInfo, meta);
     },
 
-    reportTaskDone: async function(endTime, passed, warnings, result) {
+    reportTaskDone: async function (endTime, passed, warnings, result) {
       this.sauceJsonReporter.reportTaskDone(endTime, passed, warnings, result);
       const mergedTestRun = this.sauceJsonReporter.mergeTestRuns();
 

--- a/src/job-reporter.js
+++ b/src/job-reporter.js
@@ -166,36 +166,6 @@ class JobReporter {
     }
   }
 
-  async attachToSession(id, session) {
-    const assets = session.assets.map((a) => {
-      return {
-        filename: a.name,
-        data: fs.createReadStream(a.localPath),
-      };
-    });
-
-    const reportReadable = new stream.Readable();
-    reportReadable.push(session.testRun.stringify());
-    reportReadable.push(null);
-    assets.push({
-      filename: 'sauce-test-report.json',
-      data: reportReadable,
-    });
-
-    assets.push(this.createConsoleLog(session.testRun, session.userAgent));
-
-    await this.testComposer.uploadAssets(id, assets).then(
-      (resp) => {
-        if (resp.errors) {
-          for (const err of resp.errors) {
-            console.error('Failed to upload asset:', err);
-          }
-        }
-      },
-      (e) => console.error('Failed to upload assets:', e.message),
-    );
-  }
-
   async reportSession(session) {
     if (!this.isAccountSet()) {
       return;

--- a/src/job-reporter.js
+++ b/src/job-reporter.js
@@ -143,6 +143,59 @@ class JobReporter {
     return tests;
   }
 
+  async attachTestRun(jobId, testRun) {
+    const reportReadable = new stream.Readable();
+    reportReadable.push(testRun.stringify());
+    reportReadable.push(null);
+
+    try {
+      const resp = await this.testComposer.uploadAssets(jobId, [
+        {
+          filename: 'sauce-test-report.json',
+          data: reportReadable,
+        },
+      ]);
+
+      if (resp.errors) {
+        for (const err of resp.errors) {
+          console.error('Failed to upload asset:', err);
+        }
+      }
+    } catch (e) {
+      console.error('Failed to upload test result:', e.message);
+    }
+  }
+
+  async attachToSession(id, session) {
+    const assets = session.assets.map((a) => {
+      return {
+        filename: a.name,
+        data: fs.createReadStream(a.localPath),
+      };
+    });
+
+    const reportReadable = new stream.Readable();
+    reportReadable.push(session.testRun.stringify());
+    reportReadable.push(null);
+    assets.push({
+      filename: 'sauce-test-report.json',
+      data: reportReadable,
+    });
+
+    assets.push(this.createConsoleLog(session.testRun, session.userAgent));
+
+    await this.testComposer.uploadAssets(id, assets).then(
+      (resp) => {
+        if (resp.errors) {
+          for (const err of resp.errors) {
+            console.error('Failed to upload asset:', err);
+          }
+        }
+      },
+      (e) => console.error('Failed to upload assets:', e.message),
+    );
+  }
+
   async reportSession(session) {
     if (!this.isAccountSet()) {
       return;

--- a/src/json-reporter.js
+++ b/src/json-reporter.js
@@ -182,6 +182,25 @@ function reporterFactory() {
       }, mergedTestRun);
     },
 
+    remoteTestRuns() {
+      const remoteBrowserTestRuns = this.fixtures.flatMap(
+        (f) => f.remoteBrowserTestRuns,
+      );
+
+      /**
+       * @type Map<string, TestRun[]>
+       */
+      const remoteRunsById = new Map();
+      remoteBrowserTestRuns.forEach((run) => {
+        if (!remoteRunsById.has(run.jobId)) {
+          remoteRunsById.set(run.jobId, []);
+        }
+        remoteRunsById.get(run.jobId).push(run.testRun);
+      });
+
+      return remoteRunsById;
+    },
+
     /**
      * @param {string} assetPath
      * @param {string} testName

--- a/tests/unit/fixture.test.ts
+++ b/tests/unit/fixture.test.ts
@@ -7,6 +7,11 @@ describe('BrowserTestRun', () => {
     ['Firefox 97 / macOS 10.15.7', 'Firefox', '97'],
     ['Firefox 97', 'Firefox', '97'],
     ['Firefox', 'Firefox', 'unknown'],
+    [
+      'Chrome 126.0.0.0 / Windows 10 (https://app.saucelabs.com/tests/000aa4ffc86d40bdbeebfcf165dab402)',
+      'Chrome',
+      '126.0.0.0',
+    ],
   ].forEach(([userAgent, expectedBrowserName, expectedBrowserVersion]) => {
     test(`can parse browser from userAgent (${userAgent})`, async () => {
       const sut = new BrowserTestRun(userAgent);
@@ -19,11 +24,32 @@ describe('BrowserTestRun', () => {
   [
     ['Chrome 97.0.4692.71 / macOS 10.15.7', 'macOS 10.15.7'],
     ['Firefox 97 / macOS', 'macOS'],
+    [
+      'Chrome 126.0.0.0 / Windows 10 (https://app.saucelabs.com/tests/000aa4ffc86d40bdbeebfcf165dab402)',
+      'Windows 10',
+    ],
   ].forEach(([userAgent, expectedPlatform]) => {
     test(`can parse platform from userAgent (${userAgent})`, async () => {
       const sut = new BrowserTestRun(userAgent);
 
       expect(sut.platform).toBe(expectedPlatform);
+    });
+  });
+
+  [
+    [
+      'Chrome 126.0.0.0 / Windows 10 (https://app.saucelabs.com/tests/000aa4ffc86d40bdbeebfcf165dab402)',
+      '000aa4ffc86d40bdbeebfcf165dab402',
+    ],
+    [
+      'Chrome 126.0.0.0 / Windows 10 (https://app.eu-central-1.saucelabs.com/tests/000aa4ffc86d40bdbeebfcf165dab402)',
+      '000aa4ffc86d40bdbeebfcf165dab402',
+    ],
+  ].forEach(([userAgent, expectedJobId]) => {
+    test(`can parse jobId from userAgent (${userAgent})`, async () => {
+      const sut = new BrowserTestRun(userAgent);
+
+      expect(sut.jobId).toBe(expectedJobId);
     });
   });
 });


### PR DESCRIPTION
## Description

* Improves interoperability with the saucelabs browser provider by attaching the test report to the job that executed the tests.

[DEVX-2924]

[DEVX-2924]: https://saucedev.atlassian.net/browse/DEVX-2924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ