### PR TITLE
feat: include console.log when attaching test results to sauce labs jobs

### DIFF
--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -124,7 +124,7 @@ export class Fixture {
     tr.addAssets([...screenshotAssets, ...videoAssets]);
   }
 
-  collectTestRuns() {
+  get testRuns() {
     return [...this.browserTestRuns.values()].map((bc) => bc.testRun);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,12 @@ module.exports = function () {
       for (const [jobId, runs] of remoteTestRuns) {
         const p = async () => {
           const merged = new TestRun();
+
+          // The user agent is the same for all runs of a given job.
+          merged.metadata['userAgent'] = runs.find(
+            (run) => run.metadata['userAgent'],
+          )?.metadata['userAgent'];
+
           runs.forEach((run) => {
             for (const suite of run.suites) {
               suite.metadata = run.metadata;

--- a/src/index.js
+++ b/src/index.js
@@ -94,13 +94,14 @@ module.exports = function () {
 
     reportTaskDone: async function (endTime, passed, warnings, result) {
       this.sauceJsonReporter.reportTaskDone(endTime, passed, warnings, result);
-      const mergedTestRun = this.sauceJsonReporter.mergeTestRuns();
+      const mergedTestRun = this.sauceJsonReporter.getMergedTestRun();
 
       fs.writeFileSync(this.sauceReportJsonPath, mergedTestRun.stringify());
 
-      const remoteTestRuns = this.sauceJsonReporter.remoteTestRuns();
+      const browserTestRunsByJobId =
+        this.sauceJsonReporter.getRemoteBrowserTestRunsByJobId();
       const tasks = [];
-      for (const [jobId, runs] of remoteTestRuns) {
+      for (const [jobId, runs] of browserTestRunsByJobId) {
         const p = async () => {
           const merged = new TestRun();
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import { TestRun } from '@saucelabs/sauce-json-reporter';
 
 const path = require('path');
 const fs = require('fs');
-const stream = require('node:stream');
 
 const { SauceJsonReporter } = require('./json-reporter');
 const { JobReporter } = require('./job-reporter');
@@ -111,10 +110,6 @@ module.exports = function () {
             }
           });
           merged.computeStatus();
-
-          const reportReadable = new stream.Readable();
-          reportReadable.push(merged.stringify());
-          reportReadable.push(null);
 
           await this.reporter.attachTestRun(jobId, merged);
         };

--- a/src/job-reporter.js
+++ b/src/job-reporter.js
@@ -143,6 +143,13 @@ class JobReporter {
     return tests;
   }
 
+  /**
+   * Attaches a test run to an existing Sauce Labs job.
+   *
+   * @param jobId {string}
+   * @param testRun {import('@saucelabs/sauce-json-reporter').TestRun}
+   * @returns {Promise<void>}
+   */
   async attachTestRun(jobId, testRun) {
     const reportReadable = new stream.Readable();
     reportReadable.push(testRun.stringify());
@@ -154,6 +161,7 @@ class JobReporter {
           filename: 'sauce-test-report.json',
           data: reportReadable,
         },
+        this.createConsoleLog(testRun, testRun.metadata['userAgent']),
       ]);
 
       if (resp.errors) {

--- a/src/json-reporter.js
+++ b/src/json-reporter.js
@@ -160,17 +160,15 @@ function reporterFactory() {
       return Status.Failed;
     },
 
-    collectTestRuns() {
-      const testRuns = this.fixtures.flatMap((f) => {
+    getTestRuns() {
+      return this.fixtures.flatMap((f) => {
         return f.testRuns;
       });
-
-      return testRuns;
     },
 
     mergeTestRuns() {
       const mergedTestRun = new TestRun();
-      const testRuns = this.collectTestRuns();
+      const testRuns = this.getTestRuns();
 
       return testRuns.reduce((collection, curr) => {
         for (const s of curr.suites) {

--- a/src/json-reporter.js
+++ b/src/json-reporter.js
@@ -26,17 +26,17 @@ function reporterFactory() {
     fixtures: [],
     /**
      * The currently executing test fixture
-     * @type Fixture | null
+     * @type {Fixture | null}
      */
     currentFixture: null,
     /**
      * The start time of the entire test run
-     * @type Date | null
+     * @type {Date | null}
      */
     startTime: null,
     /**
      * The end time of the entire test run
-     * @type Date | null
+     * @type {Date | null}
      */
     endTime: null,
     /**
@@ -47,7 +47,7 @@ function reporterFactory() {
     /**
      * The start time of a video recording started externally. We use this value to offset a
      * test's start time to its location in the video.
-     * @type number | null
+     * @type {number | null}
      */
     videoStartTime: null,
 

--- a/src/json-reporter.js
+++ b/src/json-reporter.js
@@ -162,7 +162,7 @@ function reporterFactory() {
 
     collectTestRuns() {
       const testRuns = this.fixtures.flatMap((f) => {
-        return f.collectTestRuns();
+        return f.testRuns;
       });
 
       return testRuns;

--- a/src/json-reporter.js
+++ b/src/json-reporter.js
@@ -166,7 +166,7 @@ function reporterFactory() {
       });
     },
 
-    mergeTestRuns() {
+    getMergedTestRun() {
       const mergedTestRun = new TestRun();
       const testRuns = this.getTestRuns();
 
@@ -180,7 +180,7 @@ function reporterFactory() {
       }, mergedTestRun);
     },
 
-    remoteTestRuns() {
+    getRemoteBrowserTestRunsByJobId() {
       const remoteBrowserTestRuns = this.fixtures.flatMap(
         (f) => f.remoteBrowserTestRuns,
       );

--- a/src/json-reporter.js
+++ b/src/json-reporter.js
@@ -41,7 +41,7 @@ function reporterFactory() {
     endTime: null,
     /**
      * A map of testIds to their startTimes
-     * @type Map<string, Date>
+     * @type {Map<string, Date>}
      */
     startTimes: new Map(),
     /**
@@ -188,7 +188,7 @@ function reporterFactory() {
       );
 
       /**
-       * @type Map<string, TestRun[]>
+       * @type {Map<string, TestRun[]>}
        */
       const remoteRunsById = new Map();
       remoteBrowserTestRuns.forEach((run) => {

--- a/tests/unit/fixture.test.ts
+++ b/tests/unit/fixture.test.ts
@@ -73,6 +73,6 @@ describe('Fixture', () => {
 
     sut.addTestWithAssets(userAgent, test, screenshotAssets, videoAssets);
 
-    expect(sut.collectTestRuns()).toMatchSnapshot();
+    expect(sut.testRuns).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Description

When attaching test results to a Sauce Labs job, also include a `console.log`.
<img width="980" alt="SCR-20240816-jduj" src="https://github.com/user-attachments/assets/75aba6f5-d36d-4a6b-8353-1511bc064c88">

