### PR TITLE
feat: Report job status for remotely executed sauce tests

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -138,15 +138,10 @@ export class Jobs {
       });
     } catch (e: unknown) {
       if (isAxiosError(e)) {
-        switch (e.response?.status) {
-          case 400:
-          case 404:
-          default:
-            debug(
-              'Unexpected http error while reporting test run data: %s',
-              e.message,
-            );
-        }
+        debug(
+          'Unexpected http error while reporting test run data: %s',
+          e.message,
+        );
       } else {
         debug('Unexpected error while reporting test run data', e);
       }

--- a/src/api.ts
+++ b/src/api.ts
@@ -132,20 +132,8 @@ export class Jobs {
   }
 
   async updateStatus(jobId: string, passed: boolean) {
-    try {
-      await this.api.put<void>(`/rest/v1/${this.username}/jobs/${jobId}`, {
-        passed,
-      });
-    } catch (e: unknown) {
-      if (isAxiosError(e)) {
-        debug(
-          'Unexpected http error while reporting test run data: %s',
-          e.message,
-        );
-      } else {
-        debug('Unexpected error while reporting test run data', e);
-      }
-      throw e;
-    }
+    await this.api.put<void>(`/rest/v1/${this.username}/jobs/${jobId}`, {
+      passed,
+    });
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { TestRun } from '@saucelabs/sauce-json-reporter';
+import { TestRun, Status } from '@saucelabs/sauce-json-reporter';
 
 const path = require('path');
 const fs = require('fs');
@@ -116,9 +116,10 @@ module.exports = function () {
               merged.addSuite(suite);
             }
           });
-          merged.computeStatus();
+          const status = merged.computeStatus();
 
           await this.reporter.attachTestRun(jobId, merged);
+          await this.reporter.updateJobStatus(jobId, status === Status.Passed);
         };
         tasks.push(p());
       }

--- a/src/job-reporter.js
+++ b/src/job-reporter.js
@@ -5,7 +5,7 @@ const stream = require('stream');
 const { Status, Test } = require('@saucelabs/sauce-json-reporter');
 const { TestComposer } = require('@saucelabs/testcomposer');
 
-const { TestRuns: TestRunsAPI } = require('./api');
+const { TestRuns: TestRunsAPI, Jobs: JobsAPI } = require('./api');
 const { CI } = require('./ci');
 
 const assetsURLMap = new Map([
@@ -49,6 +49,12 @@ class JobReporter {
       headers: {
         'User-Agent': userAgent,
       },
+    });
+
+    this.jobsAPI = new JobsAPI({
+      region: this.region,
+      username: this.username,
+      accessKey: this.accessKey,
     });
   }
 
@@ -171,6 +177,18 @@ class JobReporter {
       }
     } catch (e) {
       console.error('Failed to upload test result:', e.message);
+    }
+  }
+
+  /**
+   * @param jobId {string}
+   * @param passed {boolean}
+   */
+  async updateJobStatus(jobId, passed) {
+    try {
+      await this.jobsAPI.updateStatus(jobId, passed);
+    } catch (e) {
+      console.error('Failed to update job status:', e.message);
     }
   }
 


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Set the remote job's status based on the computed status of the test run report.

[DEVX-3024]

[DEVX-3024]: https://saucedev.atlassian.net/browse/DEVX-3024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ