### PR TITLE
ci: drop npm cache from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'npm'
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
## Description

ci: drop npm cache from release workflow